### PR TITLE
fix: reenable mutationObserver cleanup

### DIFF
--- a/packages/overlays/src/components/VisualEditingOverlay.tsx
+++ b/packages/overlays/src/components/VisualEditingOverlay.tsx
@@ -116,7 +116,7 @@ export function VisualEditingOverlay(): JSX.Element {
     recursivelyFindStegaNodes(document.body)
 
     return () => {
-      // mutationObserver.disconnect()
+      mutationObserver.disconnect()
       intersectionObserver.disconnect()
     }
   }, [


### PR DESCRIPTION
Tiny potential fix, noticed the MutationObserver disconnect method was commented out in the cleanup fn.

This may have been for a good reason (@snorrees I guess you'd have the most insight?), but noticed the observer was being instantiated many times in the Nuxt app example when toggling visual editing.