### PR TITLE
fix: prevent multiple instantiations

### DIFF
--- a/packages/overlays/src/enableVisualEditing.tsx
+++ b/packages/overlays/src/enableVisualEditing.tsx
@@ -2,6 +2,20 @@ import { Root } from 'react-dom/client'
 
 export type DisableVisualEditing = () => void
 
+let node: HTMLElement | null = null
+let root: Root | null = null
+
+function cleanup() {
+  if (root) {
+    root.unmount()
+    root = null
+  }
+  if (node) {
+    document.body.removeChild(node)
+    node = null
+  }
+}
+
 /**
  * Enables Visual Editing overlay in a page with sourcemap encoding.
  *
@@ -10,9 +24,8 @@ export type DisableVisualEditing = () => void
  * @public
  */
 export function enableVisualEditing(): DisableVisualEditing {
+  if (root || node) return cleanup
   let cancelled = false
-  let node: HTMLElement | null = null
-  let root: Root | null = null
 
   // Lazy load everything needed to render the app
   Promise.all([
@@ -33,7 +46,6 @@ export function enableVisualEditing(): DisableVisualEditing {
 
   return () => {
     cancelled = true
-    if (root) root.unmount()
-    if (node) document.body.removeChild(node)
+    cleanup()
   }
 }


### PR DESCRIPTION
Currently, calling `enableVisualEditing` multiple times results in a new overlay instantiation on each call, and I couldn't think of a use case for that as the overlay is attached to the document body, i.e. the function doesn't accept a specific DOM element/scope. 

I imagine the original thinking was using this function within a React component and therefore letting `useEffect` handle cleanup, but that doesn't necessarily translate to ways of thinking with other frameworks. For example Vue's `onMounted` hook doesn't return a cleanup function, instead it must be handled in a separate hook, and whilst that is technically what users _should_ be using, it seems sensible to have a failsafe.

This change just checks for an existing instantiation on repeated calls, alternatively we could cleanup and reinstantiate (seems more in line with React).