### PR TITLE
fix: overlays not always rendering as top item or clickable

### DIFF
--- a/packages/overlays/src/enableVisualEditing.tsx
+++ b/packages/overlays/src/enableVisualEditing.tsx
@@ -36,6 +36,8 @@ export function enableVisualEditing(): DisableVisualEditing {
 
     node = document.createElement('div')
     node.id = 'sanity-visual-editing'
+    node.style.position = 'relative'
+    node.style.zIndex = '2147483647'
     document.body.appendChild(node)
 
     const { createRoot } =


### PR DESCRIPTION
Not an elegant fix, but rather a zIndex "race to the top". Should act as a stopgap though.